### PR TITLE
Refactor/travis ci

### DIFF
--- a/frictionless_ckan_mapper/ckan_to_frictionless.py
+++ b/frictionless_ckan_mapper/ckan_to_frictionless.py
@@ -8,6 +8,11 @@ import json
 # Third-party library imports
 import slugify
 
+try:
+    json_parse_exception = json.decoder.JSONDecodeError
+except AttributeError:  # Testing against Python 2
+    json_parse_exception = ValueError
+
 
 class CKANToFrictionless:
     '''Set of methods to convert CKAN packages and resources to their
@@ -78,7 +83,7 @@ class CKANToFrictionless:
                     try:
                         value = json.loads(value)
                         resource[key] = value
-                    except (json.decoder.JSONDecodeError, TypeError):
+                    except (json_parse_exception, TypeError):
                         pass
 
         # Reformat expected output for some keys in resource
@@ -121,7 +126,7 @@ class CKANToFrictionless:
                 value = extra['value']
                 try:
                     value = json.loads(value)
-                except (json.decoder.JSONDecodeError, TypeError):
+                except (json_parse_exception, TypeError):
                     pass
                 result = {key: value}
                 outdict['extras'].update(result)

--- a/frictionless_ckan_mapper/ckan_to_frictionless.py
+++ b/frictionless_ckan_mapper/ckan_to_frictionless.py
@@ -1,57 +1,83 @@
+'''
+Convert CKAN packages and resources to their
+Frictionless equivalent.
+'''
+# Standard library imports
 import json
 
+# Third-party library imports
 import slugify
 
 
 class CKANToFrictionless:
+    '''Set of methods to convert CKAN packages and resources to their
+    Frictionless equivalent.'''
 
-    resource_mapping = {
-        'size': 'bytes',
-        'mimetype': 'mediatype',
-        'url': 'path'
-    }
+    @staticmethod
+    def _resource_keys_to_remove(resource):
+        # TODO: Do we want to keep everything except `package_id` and
+        # `position`? The current test
+        # `test_resource_path_is_set_even_for_uploaded_resources`
+        # is not expecting `url_type` in its output.
+        resource_keys_to_remove = ['package_id', 'position', 'url_type']
 
-    # TODO: Do we want to keep everything except `package_id` and
-    # `position`? The current test
-    # `test_resource_path_is_set_even_for_uploaded_resources`
-    # is not expecting `url_type` in its output.
-    resource_keys_to_remove = ['package_id', 'position', 'url_type']
+        # TODO: delete keys last as may be needed for something in processing
+        for k in resource_keys_to_remove:
+            if k in resource:
+                del resource[k]
+        return resource
+
+    @staticmethod
+    def _remap_resource_ckan_to_frictionless(resource):
+        '''Remap differences from CKAN to Frictionless resource'''
+        resource_mapping = {
+            'size': 'bytes',
+            'mimetype': 'mediatype',
+            'url': 'path'
+        }
+
+        for key, value in resource_mapping.items():
+            if key in resource:
+                resource[value] = resource[key]
+                del resource[key]
+
+                # Cast CKAN resource size to int
+                if key == 'size':
+                    if not resource[value]:  # receives `null`
+                        resource[value] = 0
+                    else:
+                        resource[value] = int(resource[value])
+        return resource
 
     def resource(self, ckandict):
         '''Convert a CKAN resource to Frictionless Resource.
 
         1. Remove unneeded keys
         2. Expand extras.
-            * Extras are already expanded to key / values by CKAN (unlike on package)
-            * ~~Apply heuristic to unjsonify (if starts with [ or { unjsonify~~
-            * JSON loads everything and on error have a string
+            * Extras are already expanded to key / values by CKAN (unlike on
+            * package) ~~Apply heuristic to unjsonify (if starts with [ or {
+            * unjsonify~~ JSON loads everything and on error have a string
         3. Map keys from CKAN to Frictionless (and reformat if needed)
         4. Remove keys with null values (CKAN has a lot of null valued keys)
         4. Apply special formatting for key fields
         '''
-        # TODO: delete keys last as may be needed for something in processing
         resource = dict(ckandict)
-        for k in self.resource_keys_to_remove:
-            if k in resource:
-                del resource[k]
+        resource = self._resource_keys_to_remove(resource)
 
         # TODO: remove as CKAN Resource does not have extras (CKAN has already
-        # # unpacked them)
+        # unpacked them)
         if 'extras' in resource:
             resource['extras'] = json.loads(resource['extras'])
 
-        # unjsonify values
-        # 1. check if string
-        # 2. if starts with [ or { => json loads it ...
-            # slightly hacky way to check if value is a jsonified array or dict
-        # 3. else do nothing 
-        for k,v in resource.items():
-            if isinstance(v, str):
-                v = v.strip()
-                if v.startswith('{') or v.startswith('['):
+        # Unjsonify values
+        # slightly hacky way to check if value is a jsonified array or dict
+        for key, value in resource.items():
+            if isinstance(value, str):
+                value = value.strip()
+                if value.startswith('{') or value.startswith('['):
                     try:
-                        v = json.loads(v)
-                        resource[k] = v
+                        value = json.loads(value)
+                        resource[key] = value
                     except (json.decoder.JSONDecodeError, TypeError):
                         pass
 
@@ -60,30 +86,63 @@ class CKANToFrictionless:
         if 'name' in resource:
             resource['name'] = slugify.slugify(resource['name']).lower()
 
-        # Remap differences from CKAN to Frictionless resource
-        for k, v in self.resource_mapping.items():
-            if k in resource:
-                resource[v] = resource[k]
-                del resource[k]
-
-                # Cast CKAN resource size to int
-                if k == 'size':
-                    if not resource[v]:  # receives `null`
-                        resource[v] = 0
-                    else:
-                        resource[v] = int(resource[v])
+        resource = self._remap_resource_ckan_to_frictionless(resource)
         return resource
 
-    package_mapping = {
-        'notes': 'description',
-        'tags': 'keywords',  # this is flattened and simplified
-    }
+    @staticmethod
+    def _remap_package_keys(ckandict, outdict):
+        '''Remap necessary package keys.'''
+        package_mapping = {
+            'notes': 'description',
+            'tags': 'keywords',  # this is flattened and simplified
+        }
+        for key, value in package_mapping.items():
+            if key in ckandict and key == 'url':
+                outdict[value] = ckandict[key]
+                del outdict[key]
+            elif key in ckandict and key == 'tags':
+                outdict[value] = []
+                for tag in ckandict[key]:
+                    outdict[value].append(tag['name'])
+                del outdict[key]
+            elif key in ckandict:
+                outdict[value] = ckandict[key]
+                del outdict[key]
+        return outdict
 
-    package_sources_mapping = {
-        'author': 'title',
-        'author_email': 'email',
-        'url': 'path',
-    }
+    @staticmethod
+    def _convert_package_extras(outdict):
+        '''Convert the structure of extras.'''
+        if outdict.get('extras'):
+            extras = outdict['extras']  # this is a list
+            outdict['extras'] = {}  # we convert to dict
+            for extra in extras:
+                key = extra['key']
+                value = extra['value']
+                try:
+                    value = json.loads(value)
+                except (json.decoder.JSONDecodeError, TypeError):
+                    pass
+                result = {key: value}
+                outdict['extras'].update(result)
+        return outdict
+
+    @staticmethod
+    def _remap_package_sources(outdict):
+        '''Remap properties in sources.'''
+        package_sources_mapping = {
+            'author': 'title',
+            'author_email': 'email',
+            'url': 'path',
+        }
+        outdict['sources'] = []
+        source = {}
+        for key, value in package_sources_mapping.items():
+            if key in outdict:
+                source[value] = outdict[key]
+                del outdict[key]
+        outdict['sources'].append(source)
+        return outdict
 
     def dataset(self, ckandict):
         '''Convert a CKAN Package (Dataset) to Frictionless Package.
@@ -97,48 +156,16 @@ class CKANToFrictionless:
         4. Apply special formatting for key fields
         '''
         outdict = dict(ckandict)
-
-        # Remap necessary package keys
-        for k, v in self.package_mapping.items():
-            if k in ckandict and k == 'url':
-                outdict[v] = ckandict[k]
-                del outdict[k]
-            elif k in ckandict and k == 'tags':
-                outdict[v] = []
-                for tag in ckandict[k]:
-                    outdict[v].append(tag['name'])
-                del outdict[k]
-            elif k in ckandict:
-                outdict[v] = ckandict[k]
-                del outdict[k]
-
-        # Convert the structure of extras
-        if outdict.get('extras'):
-            extras = outdict['extras']  # this is a list
-            outdict['extras'] = {}  # we convert to dict
-            for extra in extras:
-                key = extra['key']
-                value = extra['value']
-                try:
-                    value = json.loads(value)
-                except (json.decoder.JSONDecodeError, TypeError):
-                    pass
-                result = {key: value}
-                outdict['extras'].update(result)
-
-        # Remap properties in sources
-        outdict['sources'] = []
-        source = {}
-        for k, v in self.package_sources_mapping.items():
-            if k in outdict:
-                source[v] = outdict[k]
-                del outdict[k]
-        outdict['sources'].append(source)
+        outdict = self._remap_package_keys(ckandict, outdict)
+        outdict = self._convert_package_extras(outdict)
+        outdict = self._remap_package_sources(outdict)
 
         # Reformat expected output for some keys in package
         outdict['name'] = outdict['name'].replace('-', '_')
 
         # Reformat resources inside package
-        outdict['resources'] = [self.resource(res) for res in outdict['resources']]
+        outdict['resources'] = [
+            self.resource(res) for res in outdict['resources']
+        ]
 
         return outdict

--- a/frictionless_ckan_mapper/converter.py
+++ b/frictionless_ckan_mapper/converter.py
@@ -52,7 +52,7 @@ def dataset_to_datapackage(dataset_dict):
     :rtype: dict
 
     '''
-    PARSERS = [
+    parsers = [
         _rename_dict_key('title', 'title'),
         _rename_dict_key('version', 'version'),
         _parse_ckan_url,
@@ -63,21 +63,21 @@ def dataset_to_datapackage(dataset_dict):
         _parse_tags,
         _parse_extras,
     ]
-    dp = {
+    datapackage = {
         'name': dataset_dict['name']
     }
 
-    for parser in PARSERS:
-        dp.update(parser(dataset_dict))
+    for parser in parsers:
+        datapackage.update(parser(dataset_dict))
 
     resources = dataset_dict.get('resources')
     if resources:
-        dp['resources'] = [_convert_to_datapackage_resource(r)
-                           for r in resources]
+        datapackage['resources'] = [_convert_to_datapackage_resource(r)
+                                    for r in resources]
 
     # Ensure unique resource names
     names = {}
-    for resource in dp.get('resources', []):
+    for resource in datapackage.get('resources', []):
         if resource['name'] in names.keys():
             old_resource_name = resource['name']
             resource['name'] = resource['name'] + str(names[old_resource_name])
@@ -85,7 +85,7 @@ def dataset_to_datapackage(dataset_dict):
         else:
             names[resource['name']] = 0
 
-    return dp
+    return datapackage
 
 
 def datapackage_to_dataset(datapackage):
@@ -94,7 +94,7 @@ def datapackage_to_dataset(datapackage):
     :returns: the dataset dict
     :rtype: dict
     '''
-    PARSERS = [
+    parsers = [
         _rename_dict_key('title', 'title'),
         _rename_dict_key('version', 'version'),
         _rename_dict_key('description', 'notes'),
@@ -108,7 +108,7 @@ def datapackage_to_dataset(datapackage):
         'name': datapackage.descriptor['name'].lower()
     }
 
-    for parser in PARSERS:
+    for parser in parsers:
         dataset_dict.update(parser(datapackage.descriptor))
 
     if datapackage.resources:
@@ -180,17 +180,17 @@ def _parse_notes(dataset_dict):
 
 def _parse_license(dataset_dict):
     result = {}
-    license = {}
+    dataset_license = {}
 
     if dataset_dict.get('license_id'):
-        license['type'] = dataset_dict['license_id']
+        dataset_license['type'] = dataset_dict['license_id']
     if dataset_dict.get('license_title'):
-        license['title'] = dataset_dict['license_title']
+        dataset_license['title'] = dataset_dict['license_title']
     if dataset_dict.get('license_url'):
-        license['url'] = dataset_dict['license_url']
+        dataset_license['url'] = dataset_dict['license_url']
 
-    if license:
-        result['license'] = license
+    if dataset_license:
+        result['license'] = dataset_license
 
     return result
 
@@ -259,17 +259,17 @@ def _parse_extras(dataset_dict):
 def _datapackage_parse_license(datapackage_dict):
     result = {}
 
-    license = datapackage_dict.get('license')
-    if license:
-        if isinstance(license, dict):
-            if license.get('type'):
-                result['license_id'] = license['type']
-            if license.get('title'):
-                result['license_title'] = license['title']
-            if license.get('title'):
-                result['license_url'] = license['url']
-        elif isinstance(license, six.string_types):
-            result['license_id'] = license
+    dataset_license = datapackage_dict.get('license')
+    if dataset_license:
+        if isinstance(dataset_license, dict):
+            if dataset_license.get('type'):
+                result['license_id'] = dataset_license['type']
+            if dataset_license.get('title'):
+                result['license_title'] = dataset_license['title']
+            if dataset_license.get('title'):
+                result['license_url'] = dataset_license['url']
+        elif isinstance(dataset_license, six.string_types):
+            result['license_id'] = dataset_license
 
     return result
 
@@ -334,7 +334,7 @@ def _datapackage_parse_unknown_fields_as_extras(datapackage_dict):
     # parsers pattern to remove whatever they use from the `datapackage_dict`
     # and call this parser at last. Anything that's still in `datapackage_dict`
     # would then be added to extras.
-    KNOWN_FIELDS = [
+    known_fields = [
         'name',
         'resources',
         'license',
@@ -350,12 +350,12 @@ def _datapackage_parse_unknown_fields_as_extras(datapackage_dict):
     result = {}
     extras = [{'key': k, 'value': v}
               for k, v in datapackage_dict.items()
-              if k not in KNOWN_FIELDS]
+              if k not in known_fields]
 
     if extras:
         for extra in extras:
             value = extra['value']
-            if isinstance(value, dict) or isinstance(value, list):
+            if isinstance(value, (dict, list)):
                 extra['value'] = json.dumps(value)
         result['extras'] = extras
 

--- a/tests/test_ckan_to_frictionless.py
+++ b/tests/test_ckan_to_frictionless.py
@@ -1,3 +1,7 @@
+'''
+Tests to make sure that package and resource conversions from CKAN to
+Frictionless are... frictionless.
+'''
 import json
 
 import pytest
@@ -5,13 +9,12 @@ import pytest
 import frictionless_ckan_mapper.ckan_to_frictionless as ckan_to_frictionless
 
 
-converter = ckan_to_frictionless.CKANToFrictionless()
-
 class TestResourceConversion:
     '''Notes:
 
-    * extras do not any special testing since CKAN already just has them as key values. 
-    * we do want to test unjsonifying values since that will cover e.g. a Table Schema set in schema field
+    * extras do not any special testing since CKAN already just has them as
+    * key values. we do want to test unjsonifying values since that will
+    * cover e.g. a Table Schema set in schema field
 
     '''
 
@@ -34,17 +37,16 @@ class TestResourceConversion:
     def _test_fixtures(self):
         inpath = 'tests/fixtures/ckan_resource.json'
         exppath = 'tests/fixtures/frictionless_resource.json'
-        converter = ckan_to_frictionless.CKANToFrictionless()
         indict = json.load(open(inpath))
         exp = json.load(open(exppath))
-        out = converter.resource(indict)
+        out = self.converter.resource(indict)
         assert out == exp
 
     def test_values_are_unjsonified(self):
         '''Test values which are jsonified dict or arrays are unjsonified'''
         schema = {
             "fields": [
-                { "name": "abc", "type": "string" }
+                {"name": "abc", "type": "string"}
             ]
         }
         indict = {
@@ -52,24 +54,24 @@ class TestResourceConversion:
             "otherval": json.dumps(schema),
             "x": "{'abc': 1"
         }
-        exp =  {
+        exp = {
             "schema": schema,
             "otherval": schema,
             # fake json object - not really ... but looks like it ...
             "x": "{'abc': 1"
         }
-        out = converter.resource(indict)
+        out = self.converter.resource(indict)
         assert out == exp
 
         indict = {
             "x": "hello world",
             "y": "1.3"
-            }
+        }
         exp = {
             "x": "hello world",
             "y": "1.3"
-            }
-        out = converter.resource(indict)
+        }
+        out = self.converter.resource(indict)
         assert out == exp
 
     def test_keys_are_removed_that_should_be(self):
@@ -79,17 +81,17 @@ class TestResourceConversion:
             "url_type": "file"
         }
         exp = {}
-        out = converter.resource(indict)
+        out = self.converter.resource(indict)
         assert out == exp
 
     def test_resource_url(self):
         indict = {
             "url": "http://www.somewhere.com/data.csv"
-            }
-        exp =  {
+        }
+        exp = {
             "path": "http://www.somewhere.com/data.csv"
-            }
-        out = converter.resource(indict)
+        }
+        out = self.converter.resource(indict)
         assert out == exp
 
     def test_resource_path_is_set_even_for_uploaded_resources(self):
@@ -100,7 +102,7 @@ class TestResourceConversion:
         exp = {
             'path': 'http://www.somewhere.com/data.csv'
         }
-        out = converter.resource(indict)
+        out = self.converter.resource(indict)
         assert out == exp
 
     def test_resource_keys_pass_through(self):
@@ -114,12 +116,12 @@ class TestResourceConversion:
                     {'name': 'title', 'type': 'string'},
                 ]
             },
-            # random 
+            # random
             'adfajka': 'aaaa',
             '1dafak': 'abbbb'
         }
         exp = indict
-        out = converter.resource(indict)
+        out = self.converter.resource(indict)
         assert out == exp
 
     def test_resource_name_slugifies_the_name_and_adds_title(self):
@@ -129,7 +131,7 @@ class TestResourceConversion:
         exp = {
             'name': 'the-name'
         }
-        out = converter.resource(indict)
+        out = self.converter.resource(indict)
         assert out == exp
 
         indict = {
@@ -138,7 +140,7 @@ class TestResourceConversion:
         exp = {
             'name': 'lista-de-pibs-dos-paises-51'
         }
-        out = converter.resource(indict)
+        out = self.converter.resource(indict)
         assert out == exp
 
     def test_resource_name_converts_unicode_characters(self):
@@ -148,9 +150,9 @@ class TestResourceConversion:
         exp = {
             'name': 'mo-shi-kai-tou-nan'
         }
-        out = converter.resource(indict)
+        out = self.converter.resource(indict)
         assert out == exp
-    
+
 
 class TestPackageConversion:
     @classmethod
@@ -190,7 +192,7 @@ class TestPackageConversion:
         assert out['license'] == license
 
     def test_basic_dataset_in_setup_is_valid(self):
-        converter.dataset(self.dataset_dict)
+        self.converter.dataset(self.dataset_dict)
 
     def test_dataset_only_requires_a_name_to_be_valid(self):
         invalid_dataset_dict = {}
@@ -204,9 +206,9 @@ class TestPackageConversion:
 
         }
 
-        converter.dataset(valid_dataset_dict)
+        self.converter.dataset(valid_dataset_dict)
         with pytest.raises(KeyError):
-            converter.dataset(invalid_dataset_dict)
+            self.converter.dataset(invalid_dataset_dict)
 
     def test_dataset_name_title_and_version(self):
         self.dataset_dict.update({
@@ -214,7 +216,7 @@ class TestPackageConversion:
             'title': 'Countries GDP',
             'version': '1.0',
         })
-        result = converter.dataset(self.dataset_dict)
+        result = self.converter.dataset(self.dataset_dict)
         assert result['title'] == self.dataset_dict['title']
         assert result['name'] == self.dataset_dict['name']
         assert result['version'] == self.dataset_dict['version']
@@ -223,7 +225,7 @@ class TestPackageConversion:
         self.dataset_dict.update({
             'notes': 'Country, regional and world GDP in current US Dollars.'
         })
-        result = converter.dataset(self.dataset_dict)
+        result = self.converter.dataset(self.dataset_dict)
         assert result.get('description') == self.dataset_dict['notes']
 
     def test_dataset_author_and_source(self):
@@ -239,7 +241,7 @@ class TestPackageConversion:
             'author_email': sources[0]['email'],
             'url': sources[0]['path']
         })
-        result = converter.dataset(self.dataset_dict)
+        result = self.converter.dataset(self.dataset_dict)
         assert result.get('sources') == sources
 
     def test_dataset_tags(self):
@@ -262,7 +264,7 @@ class TestPackageConversion:
                 }
             ]
         })
-        result = converter.dataset(self.dataset_dict)
+        result = self.converter.dataset(self.dataset_dict)
         assert result.get('keywords') == keywords
 
     def test_dataset_extras(self):
@@ -274,7 +276,7 @@ class TestPackageConversion:
                 {'key': 'location', 'value': '{"country": "China"}'},
             ]
         })
-        result = converter.dataset(self.dataset_dict)
+        result = self.converter.dataset(self.dataset_dict)
         assert result.get('extras') == {
             'title_cn': u'國內生產總值',
             'years': [2015, 2016],
@@ -294,7 +296,8 @@ The test expects `license` as a dict, but the specs expect a list of licenses:
     ]
 https://specs.frictionlessdata.io/schemas/data-package.json
 
-test_dataset_maintainer -> There is no "author" in a datapackage according to the specs.
+test_dataset_maintainer -> There is no "author" in a datapackage
+according to the specs.
 Maybe this should map to contributors?
 
 test_dataset_ckan_url -> CKAN should now be using "url",

--- a/tests/test_ckan_to_frictionless.py
+++ b/tests/test_ckan_to_frictionless.py
@@ -1,3 +1,5 @@
+# !/usr/bin/python
+# coding=utf-8
 '''
 Tests to make sure that package and resource conversions from CKAN to
 Frictionless are... frictionless.


### PR DESCRIPTION
This makes Travis happy again! :tada: See [the passing build](https://travis-ci.org/github/frictionlessdata/frictionless-ckan-mapper/builds/698948952).

* Fix all errors shown by `pylama` and some more by `pylint`.
* Minor refactor to bring back compatibility with Python 2.

The only warnings left as far as refactoring go are due to `TODOS` and `FIXME` comments.