### PR TITLE
[tests,package,#19][s]: Add test_no_resources_return_empty_list

### DIFF
--- a/frictionless_ckan_mapper/ckan_to_frictionless.py
+++ b/frictionless_ckan_mapper/ckan_to_frictionless.py
@@ -148,6 +148,8 @@ class CKANToFrictionless:
         if 'resources' in outdict:
             outdict['resources'] = [self.resource(res) for res in
                     outdict['resources']]
+        else:
+            outdict['resources'] = []
 
         # TODO: do we always license_id - can we have license_title w/o
         # license_id?

--- a/tests/test_ckan_to_frictionless.py
+++ b/tests/test_ckan_to_frictionless.py
@@ -183,9 +183,10 @@ class TestPackageConversion:
             # 'license_url': 'http://opendefinition.org/licenses/odc-odbl/'
         }
         exp = {
-            "licenses": [{
+            'licenses': [{
                 'type': 'odc-odbl',
-            }]
+            }],
+            'resources': []
         }
         out = converter.dataset(indict)
         assert out == exp
@@ -276,25 +277,32 @@ class TestPackageConversion:
             'title': 'Countries GDP',
             'resources': [self.resource_dict, new_resource],
         }
-        result = converter.dataset(indict)
-        assert len(result['resources']) == 2
+        out = converter.dataset(indict)
+        assert len(out['resources']) == 2
 
         # Package has a single resource
-        result = converter.dataset(self.dataset_dict)
-        assert len(result['resources']) == 1
+        out = converter.dataset(self.dataset_dict)
+        assert len(out['resources']) == 1
 
-    # TODO: CKAN object does not necessarily have `resources` (optional)
-    # Frictionless object MUST have a `resources` property.
-    # Should the implementation raise an error as the datapackage
-    # would not be valid without at least one resource?
-    def _test_empty_resources_raise_error(self):
-        pass
+    def test_no_resources_return_empty_list(self):
+        indict = {
+            'name': 'gdp',
+            'title': 'Countries GDP',
+        }
+        exp = {
+            'name': 'gdp',
+            'title': 'Countries GDP',
+            'resources': []
+        }
+        out = converter.dataset(indict)
+        assert out == exp
 
     def test_keys_are_removed_that_should_be(self):
         indict = {
             'state': 'active'
         }
         exp = {
+            'resources': []
         }
         out = converter.dataset(indict)
         assert out == exp


### PR DESCRIPTION
  * When there is no CKAN resource(s), the expected output in
  Frictionless is a property `resources` with an empty list.

By specifying that we want an empty list to be part of the expected output when no CKAN resource is there, this resulted in modifying just a little other tests to make them pass again because they were not expecting `resources` to be there.

The tests containing at least one CKAN resource were not affected by this change.