### PR TITLE
[tests,package,#19][s]: Add test_null_values_are_stripped

### DIFF
--- a/frictionless_ckan_mapper/ckan_to_frictionless.py
+++ b/frictionless_ckan_mapper/ckan_to_frictionless.py
@@ -161,4 +161,8 @@ class CKANToFrictionless:
             if k in outdict:
                 del outdict[k]
 
+        for k in list(outdict.keys()):
+            if outdict[k] is None:
+                del outdict[k]
+
         return outdict

--- a/tests/test_ckan_to_frictionless.py
+++ b/tests/test_ckan_to_frictionless.py
@@ -382,7 +382,8 @@ class TestPackageConversion:
         }
         exp = {
             'id': '12312',
-            'title': 'title here'
+            'title': 'title here',
+            'resources': []
         }
         out = converter.dataset(indict)
         assert out == exp

--- a/tests/test_ckan_to_frictionless.py
+++ b/tests/test_ckan_to_frictionless.py
@@ -298,3 +298,16 @@ class TestPackageConversion:
         }
         out = converter.dataset(indict)
         assert out == exp
+
+    def test_null_values_are_stripped(self):
+        indict = {
+            'id': '12312',
+            'title': 'title here',
+            'format': None
+        }
+        exp = {
+            'id': '12312',
+            'title': 'title here'
+        }
+        out = converter.dataset(indict)
+        assert out == exp


### PR DESCRIPTION
This is a very simple addition: it removes the keys that have the value `null` in a CKAN package just as it is already doing it in the same way for CKAN resources.

_Note_: I took the liberty to rename the test from `test_null_values_are_removed` to `test_null_values_are_stripped` so that it matches with the name of the test we have for CKAN resources.