### PR TITLE
[Tests] Refactor TestPackageConversion and make the build pass again

### DIFF
--- a/frictionless_ckan_mapper/ckan_to_frictionless.py
+++ b/frictionless_ckan_mapper/ckan_to_frictionless.py
@@ -93,9 +93,9 @@ class CKANToFrictionless:
         4. Remove unneeded keys
         5. Apply special formatting for key fields
         '''
-        outdict = dict(ckandict) 
+        outdict = dict(ckandict)
         # Convert the structure of extras
-        # structure of extra item is {key: xxx, value: xxx} 
+        # structure of extra item is {key: xxx, value: xxx}
         if 'extras' in ckandict:
             for extra in ckandict['extras']:
                 key = extra['key']
@@ -112,7 +112,7 @@ class CKANToFrictionless:
             if k in ckandict:
                 outdict[v] = ckandict[k]
                 del outdict[k]
-        
+
         # tags
         if 'tags' in ckandict:
             outdict['keywords'] = [ tag['name'] for tag in ckandict['tags'] ]

--- a/tests/test_ckan_to_frictionless.py
+++ b/tests/test_ckan_to_frictionless.py
@@ -178,27 +178,14 @@ class TestPackageConversion:
         out = converter.dataset(indict)
         assert out == exp
 
-    def test_unjsonify_all_extra_values_in_nested_dicts(self):
+    def test_unjsonify_all_extra_values(self):
         indict = {
             'extras': [
                 {
                     'key': 'location',
-                    'value': '{"country": {"China": {"population": ' '"1233214331", "capital": "Beijing"}}}'
-                }
-            ]
-        }
-        out = converter.dataset(indict)
-        exp = {'location':
-               {'country':
-                {'China': {'population': '1233214331',
-                           'capital': 'Beijing'}}
-                }
-               }
-        assert out == exp
-
-    def test_unjsonify_all_extra_values_in_nested_lists(self):
-        indict = {
-            'extras': [
+                    'value': '{"country": {"China": {"population": '
+                             '"1233214331", "capital": "Beijing"}}}'
+                },
                 {
                     'key': 'numbers',
                     'value': '[[[1, 2, 3], [2, 4, 5]], [[7, 6, 0]]]'
@@ -206,7 +193,15 @@ class TestPackageConversion:
             ]
         }
         out = converter.dataset(indict)
-        exp = {'numbers': [[[1, 2, 3], [2, 4, 5]], [[7, 6, 0]]]}
+        exp = {
+            "location": {
+                "country":
+                {"China":
+                 {"population": "1233214331",
+                  "capital": "Beijing"}}
+            },
+            "numbers": [[[1, 2, 3], [2, 4, 5]], [[7, 6, 0]]]
+        }
         assert out == exp
 
     def test_dataset_license(self):

--- a/tests/test_ckan_to_frictionless.py
+++ b/tests/test_ckan_to_frictionless.py
@@ -56,7 +56,7 @@ class TestResourceConversion:
         exp = {
             "x": "hello world",
             "y": "1.3"
-            }
+        }
         out = converter.resource(indict)
         assert out == exp
 
@@ -160,36 +160,20 @@ class TestResourceConversion:
 
 
 class TestPackageConversion:
-    @classmethod
-    def setup_class(self):
-        self.converter = ckan_to_frictionless.CKANToFrictionless()
-
-        self.resource_dict = {
-            'id': '1234',
-            'name': 'data.csv',
-            'url': 'http://someplace.com/data.csv'
-        }
-        self.dataset_dict = {
-            'name': 'gdp',
-            'title': 'Countries GDP',
-            'version': '1.0',
-            'resources': [self.resource_dict],
-        }
-
     def test_dataset_extras(self):
         indict = {
             'extras': [
                 {'key': 'title_cn', 'value': u'國內生產總值'},
                 {'key': 'years', 'value': '[2015, 2016]'},
                 {'key': 'last_year', 'value': 2016},
-                {'key': 'location', 'value': '{"country": "China"}'},
+                {'key': 'location', 'value': '{"country": "China"}'}
             ]
         }
         exp = {
             'title_cn': u'國內生產總值',
             'years': [2015, 2016],
             'last_year': 2016,
-            'location': {'country': 'China'},
+            'location': {'country': 'China'}
         }
         out = converter.dataset(indict)
         assert out == exp
@@ -360,8 +344,8 @@ class TestPackageConversion:
         }
         exp = {
             'contributors': [{
-                    'title': 'Datopians'
-                }]
+                'title': 'Datopians'
+            }]
         }
         out = converter.dataset(indict)
         assert out == exp
@@ -384,28 +368,38 @@ class TestPackageConversion:
             ]
         }
         exp = {
-            'keywords': [ 'economy', 'worldbank' ]
+            'keywords': ['economy', 'worldbank']
         }
         out = converter.dataset(indict)
         assert out == exp
 
     def test_resources_are_converted(self):
         # Package has multiple resources
-        new_resource = {
+        resource_1 = {
+            'id': '1234',
+            'name': 'data.csv',
+            'url': 'http://someplace.com/data.csv'
+        }
+        resource_2 = {
             'id': '12345',
             'name': 'data2.csv',
             'url': 'http://someotherplace.com/data2.csv'
         }
-        indict = {
+        indict_2_resources = {
             'name': 'gdp',
             'title': 'Countries GDP',
-            'resources': [self.resource_dict, new_resource],
+            'resources': [resource_1, resource_2]
         }
-        out = converter.dataset(indict)
+        indict_1_resource = {
+            'name': 'gdp',
+            'title': 'Countries GDP',
+            'resources': [resource_1]
+        }
+        out = converter.dataset(indict_2_resources)
         assert len(out['resources']) == 2
 
         # Package has a single resource
-        out = converter.dataset(self.dataset_dict)
+        out = converter.dataset(indict_1_resource)
         assert len(out['resources']) == 1
 
     def test_all_keys_are_passed_through(self):


### PR DESCRIPTION
Commit https://github.com/frictionlessdata/frictionless-ckan-mapper/commit/dbcc7056d24ea20a2c1bf795cc48661e916d6790 brings a solution to this comment:

> let's not self.dataset stuff - let's just create an explicit dict

Commit https://github.com/frictionlessdata/frictionless-ckan-mapper/commit/64fe09a8fd9e56daa1f421f587302e463376f57a brings a solution to that comment:

> I get the value of separate tests here but i think you could probably just have one and multiple entries in extras dict. It would be simpler and easier to follow i think.

Finally, commit https://github.com/frictionlessdata/frictionless-ckan-mapper/commit/b3de33660d24e837fd755ff208a69245693953b0 brings a fix to the build that started to fail because of Pylama:

```
frictionless_ckan_mapper/ckan_to_frictionless.py:96:33: W291 trailing whitespace [pep8]
frictionless_ckan_mapper/ckan_to_frictionless.py:98:60: W291 trailing whitespace [pep8]
frictionless_ckan_mapper/ckan_to_frictionless.py:115:1: W293 blank line contains whitespace [pep8]
```

This confirms that those warnings are actually enough to make the build fail. If we don't care about those warnings, a simple fix would be to ignore them as we did earlier in `pylama.ini`:

```
[pylama:*]
ignore = E128,E201,E202,W291,W293
```