### PR TITLE
Add first few tests for Frictionless => CKAN package conversion

### DIFF
--- a/frictionless_ckan_mapper/frictionless_to_ckan.py
+++ b/frictionless_ckan_mapper/frictionless_to_ckan.py
@@ -1,0 +1,55 @@
+import json
+
+try:
+    json_parse_exception = json.decoder.JSONDecodeError
+except AttributeError:  # Testing against Python 2
+    json_parse_exception = ValueError
+
+
+class FrictionlessToCKAN:
+
+    # TODO: How do we map the required CKAN `package_id`?
+    # TODO: In CKAN, `private` is another required field:
+    #       set default value to False?
+
+    resource_mapping = {
+        'bytes': 'size',
+        'mediatype': 'mimetype',
+        'path': 'url'
+    }
+
+    # TODO: Do we passthrough all the FD properties not found in CKAN?
+    # `data`: This replaces Resource.path if it is not specified.
+    #         However, it is not an URL. Should it just passthrough?
+    # `homepage`: Does this passthrough? What if we also have FD Resource.path
+    #             => we can't map both to CKAN Resource.url
+    # `licenses`: How do we map multiple licenses from Frictionless to CKAN?
+    resource_keys_to_remove = [
+        '',
+    ]
+
+    def resource(self, fddict):
+        '''Convert a Frictionless resource to a CKAN resource.
+
+        # TODO: (the following is inaccurate)
+
+        1. Remove unneeded keys (are there any keys to remove?)
+        2. Convert extras: "dict" to "list of dict".
+        3. Map keys from Frictionless to CKAN (and reformat if needed).
+        4. Remove keys with null values.
+        5. Apply special formatting (if any) for key fields e.g. slugify
+        '''
+        pass
+
+    def package(self, fddict):
+        '''Convert a Frictionless package to a CKAN package (dataset).
+
+        # TODO: (the following is inaccurate)
+
+        1. Copy extras across.  # Is this true?
+        2. Map keys from Frictionless to CKAN (and reformat if needed).
+        3. Remove keys with null values (CKAN has a lot of null valued keys).
+        4. Remove unneeded keys.
+        5. Apply special formatting for key fields.
+        '''
+        pass

--- a/frictionless_ckan_mapper/frictionless_to_ckan.py
+++ b/frictionless_ckan_mapper/frictionless_to_ckan.py
@@ -8,24 +8,41 @@ except AttributeError:  # Testing against Python 2
 
 class FrictionlessToCKAN:
 
-    # TODO: How do we map the required CKAN `package_id`?
-    # TODO: In CKAN, `private` is another required field:
-    #       set default value to False?
-
     resource_mapping = {
         'bytes': 'size',
         'mediatype': 'mimetype',
         'path': 'url'
     }
 
-    # TODO: Do we passthrough all the FD properties not found in CKAN?
-    # `data`: This replaces Resource.path if it is not specified.
-    #         However, it is not an URL. Should it just passthrough?
-    # `homepage`: Does this passthrough? What if we also have FD Resource.path
-    #             => we can't map both to CKAN Resource.url
-    # `licenses`: How do we map multiple licenses from Frictionless to CKAN?
-    resource_keys_to_remove = [
-        '',
+    package_mapping = {
+        'description': 'notes',
+        'homepage': 'url',
+        'keywords': 'tags'
+    }
+
+    # Any key not in this list is passed as is inside "extras".
+    # Further processing will happen for possible matchings, e.g.
+    # contributor <=> author
+    CKAN_package_keys = [
+        "author",
+        "author_email",
+        "groups",
+        "license_id",
+        "maintainer",
+        "maintainer_email",
+        "name",
+        "notes",
+        "owner_org",
+        "private",
+        "relationships_as_object",
+        "relationships_as_subject",
+        "resources",
+        "state",
+        "tags",
+        "title",
+        "type",
+        "url",
+        "version"
     ]
 
     def resource(self, fddict):
@@ -33,11 +50,10 @@ class FrictionlessToCKAN:
 
         # TODO: (the following is inaccurate)
 
-        1. Remove unneeded keys (are there any keys to remove?)
-        2. Convert extras: "dict" to "list of dict".
-        3. Map keys from Frictionless to CKAN (and reformat if needed).
-        4. Remove keys with null values.
-        5. Apply special formatting (if any) for key fields e.g. slugify
+        1. Convert extras: "dict" to "list of dict".
+        2. Map keys from Frictionless to CKAN (and reformat if needed).
+        3. Apply special formatting (if any) for key fields e.g. slugify.
+        4. Map anything not in CKAN inside the "extras" key.
         '''
         pass
 
@@ -46,10 +62,8 @@ class FrictionlessToCKAN:
 
         # TODO: (the following is inaccurate)
 
-        1. Copy extras across.  # Is this true?
-        2. Map keys from Frictionless to CKAN (and reformat if needed).
-        3. Remove keys with null values (CKAN has a lot of null valued keys).
-        4. Remove unneeded keys.
-        5. Apply special formatting for key fields.
+        1. Map keys from Frictionless to CKAN (and reformat if needed).
+        2. Apply special formatting (if any) for key fields.
+        3. Copy extras across inside the "extras" key.
         '''
         pass

--- a/frictionless_ckan_mapper/frictionless_to_ckan.py
+++ b/frictionless_ckan_mapper/frictionless_to_ckan.py
@@ -68,4 +68,6 @@ class FrictionlessToCKAN:
         '''
         outdict = fddict
 
+        outdict['name'] = outdict['name'].lower()
+
         return outdict

--- a/frictionless_ckan_mapper/frictionless_to_ckan.py
+++ b/frictionless_ckan_mapper/frictionless_to_ckan.py
@@ -66,4 +66,6 @@ class FrictionlessToCKAN:
         2. Apply special formatting (if any) for key fields.
         3. Copy extras across inside the "extras" key.
         '''
-        pass
+        outdict = fddict
+
+        return outdict

--- a/tests/test_frictionless_to_ckan.py
+++ b/tests/test_frictionless_to_ckan.py
@@ -11,5 +11,15 @@ converter = frictionless_to_ckan.FrictionlessToCKAN()
 class TestResourceConversion:
     pass
 
+
 class TestPackageConversion:
-    pass
+    def test_name_title_and_version(self):
+        indict = {
+            'name': 'gdp',
+            'title': 'Countries GDP',
+            'version': '1.0',
+        }
+        result = converter.package(indict)
+        assert result['name'] == indict['name']
+        assert result['title'] == indict['title']
+        assert result['version'] == indict['version']

--- a/tests/test_frictionless_to_ckan.py
+++ b/tests/test_frictionless_to_ckan.py
@@ -1,0 +1,15 @@
+# coding=utf-8
+
+import pytest
+
+import frictionless_ckan_mapper.frictionless_to_ckan as frictionless_to_ckan
+
+
+converter = frictionless_to_ckan.FrictionlessToCKAN()
+
+
+class TestResourceConversion:
+    pass
+
+class TestPackageConversion:
+    pass

--- a/tests/test_frictionless_to_ckan.py
+++ b/tests/test_frictionless_to_ckan.py
@@ -23,3 +23,8 @@ class TestPackageConversion:
         assert result['name'] == indict['name']
         assert result['title'] == indict['title']
         assert result['version'] == indict['version']
+
+    def test_name_is_lowercased(self):
+        indict = {'name': 'ThEnAmE'}
+        result = converter.package(indict)
+        assert result['name'] == indict['name'].lower()


### PR DESCRIPTION
* Create `frictionless_to_ckan.py` with basic class and functions needed.
* Add comments in `frictionless_to_ckan.py` and document with a docstring.
* Remove TODOs not needed anymore.
* Update function docstrings to reflect the desired behavior of the algorithm.
* Refactor over old tests to start with a few basic ones that fail.
* Make the tests pass with minimal implementation.