### PR TITLE
[formatting,pylama][xs]: Fix pylama issue with long line breaking build

### DIFF
--- a/frictionless_ckan_mapper/frictionless_to_ckan.py
+++ b/frictionless_ckan_mapper/frictionless_to_ckan.py
@@ -103,7 +103,9 @@ def package(fddict):
                 break
 
     if outdict.get('keywords'):
-        outdict['tags'] = [ {'name': keyword} for keyword in outdict['keywords'] ]
+        outdict['tags'] = [
+            {'name': keyword} for keyword in outdict['keywords']
+        ]
         del outdict['keywords']
 
     final_dict = dict(outdict)


### PR DESCRIPTION
* Fix error `E501 line too long (82 > 79 characters) [pep8]` with pylama.

If we want to avoid this error in the future, we can change `pylama.ini` by either:

* Increasing the allowed line length with:
```
[pylama:pep8]
max_line_length=100
```

* or ignore this error entirely with:
```
[pylama:*]
ignore = E128,E201,E202,E501
```

or run `pylama frictionless_ckan_mapper` in the root directory of the project to make sure there is no output.