### PR TITLE
Implement tests for license(s) by taking care of `license_url`

### DIFF
--- a/frictionless_ckan_mapper/frictionless_to_ckan.py
+++ b/frictionless_ckan_mapper/frictionless_to_ckan.py
@@ -26,6 +26,7 @@ ckan_package_keys = [
     'groups',
     'license_id',
     'license_title',
+    'license_url',
     'maintainer',
     'maintainer_email',
     'name',
@@ -88,6 +89,7 @@ def package(fddict):
     if 'licenses' in outdict and outdict['licenses']:
         outdict['license_id'] = outdict['licenses'][0].get('name')
         outdict['license_title'] = outdict['licenses'][0].get('title')
+        outdict['license_url'] = outdict['licenses'][0].get('path')
 
     if outdict.get('contributors'):
         for c in outdict['contributors']:

--- a/tests/test_frictionless_to_ckan.py
+++ b/tests/test_frictionless_to_ckan.py
@@ -86,25 +86,24 @@ class TestPackageConversion:
     def test_dataset_license(self):
         indict = {
             'licenses': [{
-                'name': 'odc-odbl'
+                'name': 'odc-odbl',
+                'path': 'http://example.com/file.csv',
             }]
         }
         exp = {
             'license_id': 'odc-odbl',
             'license_title': None,
+            'license_url': 'http://example.com/file.csv',
             'extras': [
                 {
                     'key': 'licenses',
-                    'value': json.dumps([{ 'name': 'odc-odbl' }])
+                    'value': json.dumps(indict['licenses'])
                 }
             ]
         }
         out = converter.package(indict)
         assert out == exp
 
-
-        # TODO: reinstate with proper extras support
-        '''
         indict = {
             'licenses': [{
                 'title': 'Open Data Commons Open Database License',
@@ -113,7 +112,14 @@ class TestPackageConversion:
         }
         exp = {
             'license_id': 'odc-odbl',
-            'license_title': 'Open Data Commons Open Database License'
+            'license_title': 'Open Data Commons Open Database License',
+            'license_url': None,
+            'extras': [
+                {
+                    'key': 'licenses',
+                    'value': json.dumps(indict['licenses'])
+                }
+            ]
         }
         out = converter.package(indict)
         assert out == exp
@@ -123,24 +129,27 @@ class TestPackageConversion:
             'licenses': [
                 {
                     'title': 'Open Data Commons Open Database License',
-                    'type': 'odc-pddl'
+                    'name': 'odc-pddl'
                 },
                 {
                     'title': 'Creative Commons CC Zero License (cc-zero)',
-                    'type': 'cc-zero'
+                    'name': 'cc-zero'
                 }
             ]
         }
         exp = {
-            'extras': [{
-                'licenses': indict['licenses']
-            }],
             'license_id': 'odc-pddl',
             'license_title': 'Open Data Commons Open Database License',
+            'license_url': None,
+            'extras': [
+                {
+                    'key': 'licenses',
+                    'value': json.dumps(indict['licenses'])
+                }
+            ]
         }
         out = converter.package(indict)
         assert out == exp
-        '''
 
     # TODO: get clear on the spelling of the key "organization".
     # It's "organisation" in the JSON schema at
@@ -249,5 +258,5 @@ class TestPackageConversion:
             ]
         }
         out = converter.package(indict)
-        out['extras'] = sorted(out['extras'], key = lambda i: i['key'])
+        out['extras'] = sorted(out['extras'], key=lambda i: i['key'])
         assert out == exp


### PR DESCRIPTION
**TL;DR**: I gave it a try and "fixed" (to confirm) the existing tests for licenses by also taking into account `license_url`. CKAN=>Frictionless was flawed in its implementation and Frictionless=>CKAN required very minor additions.

---

The work has been split into two commits, but it should not be too hard to follow in one go:

* Commit https://github.com/frictionlessdata/frictionless-ckan-mapper/commit/8c4f15feea5d2e965d0dade8f3ed4c119890adff does CKAN to Frictionless
* Commit https://github.com/frictionlessdata/frictionless-ckan-mapper/commit/b8f37af23435ad0513da22acea9068c29f6fff99 does Frictionless to CKAN
* Comments left to explain a bit more this PR: https://github.com/frictionlessdata/frictionless-ckan-mapper/pull/32/files

Also, Travis approves :grin:.
