### PR TITLE
[setup,#15,#18][m]: Final adjustments to prepare PyPi release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ ENV/
 
 # VS Code
 .vscode/
+
+# Makefile
+.make-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ sudo:
 dist:
   trusty
 
-addons:
-  apt:
-    packages:
-      - pandoc
-
 language:
   python
 
@@ -29,11 +24,6 @@ script:
 
 after_success:
   - coveralls
-
-before_deploy:
-  - pandoc --version
-  - pandoc -f markdown_github -t rst -o README.rst README.md
-  - mv README.rst README.md
 
 deploy:
   provider: pypi

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,27 @@
-.PHONY: all install list readme release test version
+PYTHON := python
+PIP := pip
+GIT := git
 
+BUILD_DIR := build
+DIST_DIR := dist
+SENTINELS := .make-cache
+
+SOURCE_FILES := $(shell find ./frictionless_ckan_mapper -type f -name "*.py")
 
 PACKAGE := $(shell grep '^PACKAGE =' setup.py | cut -d "'" -f2)
 VERSION := $(shell head -n 1 $(PACKAGE)/VERSION)
+
+.PHONY: all dist distclean install list release test version
+
+## Clean all generated files
+distclean:
+	rm -rf $(BUILD_DIR) $(DIST_DIR)
+	rm -rf $(SENTINELS)/dist
+
+## Create distribution files to upload to pypi
+dist: $(SENTINELS)/dist
+
+
 
 all: list
 
@@ -12,18 +31,32 @@ install:
 list:
 	@grep '^\.PHONY' Makefile | cut -d' ' -f2- | tr ' ' '\n'
 
-readme:
-	pip install md-toc
-	md_toc -p README.md github --header-levels 3
-	sed -i '/(#tableschema-spss-py)/,+2d' README.md
+## Upload a release of the package to PyPi and create a Git tag
+release: $(SENTINELS)/dist
+	@echo
+	@echo "You are about to release authoritative version $(VERSION)"
+	@echo "This will:"
+	@echo " - Create a git tag release-$(VERSION)"
+	@echo " - Create a release package and upload it to pypi"
+	@echo
+	@echo "Continue? (hit Enter to continue or Ctrl+C to stop)"
+	@read
+	$(GIT) tag release-$(VERSION)
+	$(GIT) push --tags
+	$(PYTHON) -m twine upload dist/*
 
-release:
-	git checkout master && git pull origin && git fetch -p && git diff
-	@echo "\nContinuing in 10 seconds. Press <CTRL+C> to abort\n" && sleep 10
-	@git log --pretty=format:"%C(yellow)%h%Creset %s%Cgreen%d" --reverse -20
-	@echo "\nReleasing v$(VERSION) in 10 seconds. Press <CTRL+C> to abort\n" && sleep 10
-	git commit -a -m 'v$(VERSION)' && git tag -a v$(VERSION) -m 'v$(VERSION)'
-	git push --follow-tags
+$(SENTINELS):
+	mkdir $@
+
+$(SENTINELS)/dist-setup: | $(SENTINELS)
+	$(PIP) install -U pip wheel twine
+	@touch $@
+
+$(SENTINELS)/dist: $(SENTINELS)/dist-setup $(DIST_DIR)/frictionless-ckan-mapper-$(VERSION).tar.gz $(DIST_DIR)/frictionless-ckan-mapper-$(VERSION)-py2.py3-none-any.whl | $(SENTINELS)
+	@touch $@
+
+$(DIST_DIR)/frictionless-ckan-mapper-$(VERSION).tar.gz $(DIST_DIR)/frictionless-ckan-mapper-$(VERSION)-py2.py3-none-any.whl: $(SOURCE_FILES) setup.py | $(SENTINELS)/dist-setup
+	$(PYTHON) setup.py sdist bdist_wheel --universal
 
 test:
 	pylama $(PACKAGE)

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,7 @@ INSTALL_REQUIRES = [
 ]
 TESTS_REQUIRE = [
     'pylama',
-    'tox',
-    'requests_mock'
+    'tox'
 ]
 README = read('README.md')
 VERSION = read(PACKAGE, 'VERSION')
@@ -41,13 +40,20 @@ setup(
     extras_require={'develop': TESTS_REQUIRE},
     zip_safe=False,
     long_description=README,
-    description='{{ DESCRIPTION }}',
+    long_description_content_type='text/markdown',
+    description='A library for mapping CKAN metadata <=> Frictionless metadata.',
     author='Open Knowledge International',
     url='https://github.com/frictionlessdata/frictionless_ckan_mapper',
+    copyright='Copyright 2020 (c) Viderum Inc. / Datopian',
     license='MIT',
     keywords=[
         'data',
-        'ckan'
+        'ckan',
+        'frictionless',
+        'conversion',
+        'package',
+        'dataset',
+        'resource'
     ],
     classifiers=[
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,6 @@ deps=
   pytest
   pytest-cov
   coverage
-  mock
-  requests_mock
-  datapackage>=1.0,<2.0
 passenv=
   CI
   TRAVIS


### PR DESCRIPTION
**TL;DR:** Make some necessary changes so that we can publish to PyPi with `make release` and fix some formatting issues.

* Add `.make-cache` to `.gitignore`, which is being generated by the
  Makefile.
* Remove the `pandoc` dependency from `.travis.yml`: it messes up with
  the existing Markdown during the conversion and PyPi fully supports the
  Markdown format since 2018, so it's not necessary.
* Add new commands to the Makefile to build the package more easily.
* Remove the `readme` command from Makefile: the README is already well
  formatted and doesn't require this extra `md-toc` dependency.
* Change the `release` command in the Makefile to publish as a PyPi
  package instead of only deploying to GitHub.
* Remove unused dependency in `setup.py`.
* Update `setup.py` to add a description for the package, a copyright
  and relevant keywords.
* Update `tox.ini` to remove unused test dependencies. We don't mock
  anything from network requests and `datapackage` was rendered
  unnecessary as we have created our own simple dictionaries to reduce
  dependencies.