### PR TITLE
[c2f,bug,#33][s]: Add test against empty `keywords`

### DIFF
--- a/frictionless_ckan_mapper/ckan_to_frictionless.py
+++ b/frictionless_ckan_mapper/ckan_to_frictionless.py
@@ -111,6 +111,8 @@ def dataset(ckandict):
     if 'tags' in ckandict:
         outdict['keywords'] = [tag['name'] for tag in ckandict['tags']]
         del outdict['tags']
+    if outdict.get("keywords") == []:
+        del outdict["keywords"]
 
     # author, maintainer => contributors
     # what to do if contributors already there? Options:

--- a/tests/fixtures/full_ckan_package_first_round_trip.json
+++ b/tests/fixtures/full_ckan_package_first_round_trip.json
@@ -34,7 +34,6 @@
   "type": "dataset",
   "version": "",
   "url": "",
-  "keywords": [],
   "extras": [
     {
       "key": "creator_user_id",

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -59,3 +59,18 @@ class TestPackageConversion:
         # - Keys defined in CKAN but ignored in Frictionless, such as `id`
         #   (because a Frictionless package doesn't have an id property) will
         #   also go to 'extras'.
+
+    def test_ckan_round_trip_does_not_generate_empty_keywords(self):
+        '''When CKAN does not have `tags`, it should not create the empty
+        `keywords` list in a Frictionless package. This would lead to a round
+        trip where `tags` is also not there nor empty.'''
+        ckan1 = {
+            "x": "yyy",
+            "tags": []
+        }
+        exp_fd1 = {"x": "yyy"}
+        fd1 = ckan_to_frictionless.dataset(ckan1)
+        assert fd1 == exp_fd1
+        ckan2 = frictionless_to_ckan.package(fd1)
+        exp_ckan2 = {'extras': [{'key': 'x', 'value': 'yyy'}]}
+        assert ckan2 == exp_ckan2


### PR DESCRIPTION
Fix bug discussed in #33 on generating `'keywords': []` when we have `'tags': []` from converting from CKAN to Frictionless.

* Add test_ckan_round_trip_does_not_generate_empty_keywords.
* Do not create empty list of `keywords` when tags are empty.