### PR TITLE
[f2c,bug,test,#33][s]: Remap resources keys after one round trip

### DIFF
--- a/tests/fixtures/full_ckan_package_first_round_trip.json
+++ b/tests/fixtures/full_ckan_package_first_round_trip.json
@@ -25,9 +25,9 @@
       "tracking_summary": { "recent": 0, "total": 0 },
       "url_type": "upload",
       "versions_upload_timestamp": "2020-06-25T11:33:49.567522",
-      "bytes": 40,
-      "mediatype": "text/csv",
-      "path": "http://localhost:5000/dataset/1f7db1f1-1400-4572-a860-0977326a5521/resource/e778ca29-5fb7-4063-ad9b-68040f88ab8a/download/mini-csv.csv"
+      "size": 40,
+      "mimetype": "text/csv",
+      "url": "http://localhost:5000/dataset/1f7db1f1-1400-4572-a860-0977326a5521/resource/e778ca29-5fb7-4063-ad9b-68040f88ab8a/download/mini-csv.csv"
     }
   ],
   "title": "Testing",


### PR DESCRIPTION
Fix the problem mentioned in issue #33:

> Inside a CKAN resource, we have the size key. When we do a round trip when converting a package, this key is mapped to bytes instead of size (because of the Frictionless conversion).

* Converting from CKAN to Frictionless was working. The second
  conversion from Frictionless to CKAN was not converting
  the name of resource keys properly.
* For instance, we had url->path->path instead of url->path->url
  and size->bytes->bytes instead of size->bytes->size.
* This commit fixes this behavior and conversion from
  CKAN->Frictionless->CKAN now remaps the name of keys in resources
  as expected.
* This also fixes an error in full_ckan_package_first_round_trip.json
  where the name of resource keys from the original CKAN package didn't
  match after a first round trip.