### PR TITLE
[f2c,tests,#42][s]: Add tests for single contributors and maintainers (no implementation)

### DIFF
--- a/tests/test_frictionless_to_ckan.py
+++ b/tests/test_frictionless_to_ckan.py
@@ -232,6 +232,59 @@ class TestPackageConversion:
         out = converter.package(indict)
         assert out == exp
 
+    def test_single_contributor_is_not_in_extras(self):
+        indict = {
+            'author': 'Patricio Del Boca',
+            'author_email': '',
+            'extras': [
+                {'key': 'contributors',
+                    'value': (
+                        '[{"role": "author", "email": "", "title": '
+                        '"Patricio Del Boca"}]'
+                    )
+                 }
+            ]
+        }
+        exp = {
+            'author': 'Patricio Del Boca',
+            'author_email': '',
+            'extras': []
+        }
+        out = converter.package(indict)
+        assert out == exp
+
+    def test_multiple_authors_and_maintainers_are_converted(self):
+        indict = {
+            'author': 'Patricio',
+            'author_email': '',
+            'extras': [
+                {'key': 'contributors',
+                 'value': (
+                     '[{"role": "author", "email": "", "title": "Patricio"},'
+                     '{"role": "maintainer", "email": "", "title": "Rufus"},'
+                     '{"role": "author", "email": "", "title": "Paul"}]'
+                 )
+                }
+            ]
+        }
+        exp = {
+            'author': 'Patricio',
+            'author_email': '',
+            'maintainer': 'Rufus',
+            'maintainer_email': '',
+            'extras': [
+                {'key': u'contributors',
+                 'value': (
+                     '[{"role": "author", "email": "", "title": "Patricio"},'
+                     '{"role": "maintainer", "email": "", "title": "Rufus"},'
+                     '{"role": "author", "email": "", "title": "Paul"}]'
+                 )
+                }
+            ]
+        }
+        out = converter.package(indict)
+        assert out == exp
+
     def test_keywords_converted_to_tags(self):
         keywords = ['economy!!!', 'World Bank']
         indict = {'keywords': keywords}


### PR DESCRIPTION
`test_single_contributor_is_not_in_extras` highlights the fact that we keep duplicate info while `test_multiple_authors_and_maintainers_are_converted` shows that we are not testing for info found in `extras` that's not in the package originally, such as when we have no maintainer, it is not being added from the extras.

* Add `test_single_contributor_is_not_in_extras` to check that when a
  single contributor is listed in `extras`, it is removed from `extras`
  during the conversion to avoid duplicate information.
* Add `test_multiple_authors_and_maintainers_are_converted` to check
  that when we have both maintainers and authors, the first of each type
  is kept and added if not already present in the package before the
  conversion.