### PR TITLE
Fix pep-0263 by adding coding to files

### DIFF
--- a/frictionless_ckan_mapper/ckan_to_frictionless.py
+++ b/frictionless_ckan_mapper/ckan_to_frictionless.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import json
 
 try:

--- a/frictionless_ckan_mapper/frictionless_to_ckan.py
+++ b/frictionless_ckan_mapper/frictionless_to_ckan.py
@@ -113,24 +113,25 @@ def package(fddict):
                 outdict['maintainer_email'] = c.get('email')
                 break
 
-        # we remove contributors where we have extracted everything into ckan core
-        # that way it won't end up in extras
-        # this helps ensure that round tripping with ckan is good
+        # we remove contributors where we have extracted everything into
+        # ckan core that way it won't end up in extras
+        # this helps ensure that round tripping with ckan is good
         # when have we extracted everything?
         # if contributors has length 1 and role in author or maintainer
-        # or contributors == 2 and no of authors and maintainer types <= 1
+        # or contributors == 2 and no of authors and maintainer types <= 1
         if (
-            (len (outdict.get('contributors')) == 1 and
+            (len(outdict.get('contributors')) == 1 and
                 outdict['contributors'][0].get('role') in [None, 'author',
                     'maintainer'])
             or
-            (len (outdict.get('contributors')) == 2 and
+            (len(outdict.get('contributors')) == 2 and
                 [c.get('role') for c in outdict['contributors']]
-                not in ([None, None], ['maintainer', 'maintainer'], ['author', 'author'])
-                )
-            ):
+                not in (
+                    [None, None],
+                    ['maintainer', 'maintainer'],
+                    ['author', 'author']))
+                    ):
             outdict.pop('contributors', None)
-
 
     if outdict.get('keywords'):
         outdict['tags'] = [

--- a/frictionless_ckan_mapper/frictionless_to_ckan.py
+++ b/frictionless_ckan_mapper/frictionless_to_ckan.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import json
 
 try:


### PR DESCRIPTION
# Overview

When trying to run is throwing the following error due to a block comment in one of the files:
```
File "/home/pdelboca/Repos/ckanext-versioning/.venv/src/frictionless-ckan-mapper/frictionless_ckan_mapper/frictionless_to_ckan.py", line 115
SyntaxError: Non-ASCII character '\xc2' in file /home/pdelboca/Repos/ckanext-versioning/.venv/src/frictionless-ckan-mapper/frictionless_ckan_mapper/frictionless_to_ckan.py on line 115, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

I have added `# coding=utf-8` to both files to avoid this. Also did some pep8 fixes to make the build pass since it is not passing in master for the latest commit.

---

Please preserve this line to notify @amercader (lead of this repository)
