### PR TITLE
Don't remove field 'extras' from ckan dict

### DIFF
--- a/frictionless_ckan_mapper/ckan_to_frictionless.py
+++ b/frictionless_ckan_mapper/ckan_to_frictionless.py
@@ -95,6 +95,7 @@ def dataset(ckandict):
     # Convert the structure of extras
     # structure of extra item is {key: xxx, value: xxx}
     if 'extras' in ckandict:
+        extras_dict = {}
         for extra in ckandict['extras']:
             key = extra['key']
             value = extra['value']
@@ -102,14 +103,15 @@ def dataset(ckandict):
                 value = json.loads(value)
             except (json_parse_exception, TypeError):
                 pass
-            outdict[key] = value
-        del outdict['extras']
+            extras_dict[key] = value
+        outdict['extras'] = extras_dict
 
     # Map dataset keys
     for key, value in dataset_mapping.items():
         if key in ckandict:
             outdict[value] = ckandict[key]
-            del outdict[key]
+            if key != value:
+                del outdict[key]
 
     # map resources inside dataset
     if 'resources' in ckandict:


### PR DESCRIPTION
Currently if a CKAN dict describing a dataset contains the field "extras", the field is removed after it's converted to a datapackage, making the following test ckanext-datapackager faile https://github.com/frictionlessdata/ckanext-datapackager/blob/main/ckanext/datapackager/tests/lib/test_converter.py#L135